### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/react-layout-masonry/security/code-scanning/1](https://github.com/sibiraj-s/react-layout-masonry/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions. The minimal required permission for this workflow is `contents: read`, since it only checks out code and runs tests. This block should be added at the root level of the workflow file (above `jobs:`), so it applies to all jobs unless overridden. No changes to the steps or other configuration are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
